### PR TITLE
Added logging option for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ clean:
 	@$(RM) tests/*/*.diff
 	@$(RM) tests/*.diff
 	@$(RM) failed_tests.txt
-	@$(RM) TESTS_REPORT.log
 
 post-clean:
 	@$(RM) saved*

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,15 @@ CLASSPATH=$(PO_UILIB_DIR)/po-uilib.jar:$(XXL_DIR)/xxl-core/xxl-core.jar:$(XXL_DI
 CURRENT_DIR=$(shell pwd | sed 's/ /\\ /g')
 ccred=\033[0;31m\033[1m
 ccgreen=\033[0;32m\033[1m
+ccyellow=\033[1;33m\033[1m
 ccend=\033[0m
 TESTS=$(sort $(shell find tests -type f -name '*.in'))
 TESTS_NUMBER=$(shell find tests -type f -name '*.in' | wc -l)
 TESTS_FAILED:=$$(find tests -type f -name '*.diff' | wc -l)
+REPORT_FILE=TESTS_REPORT.log
+MAKEFLAGS += --no-print-directory
 
-.PHONY: all clean force
+.PHONY: all clean force log
 all: clean $(PO_UILIB_DIR)/po-uilib.jar $(XXL_DIR)/xxl-core/xxl-core.jar $(XXL_DIR)/xxl-app/xxl-app.jar $(TESTS) post-clean
 	@printf "\n\n"
 	@if [ $(TESTS_FAILED) -gt 0 ]; \
@@ -20,6 +23,18 @@ all: clean $(PO_UILIB_DIR)/po-uilib.jar $(XXL_DIR)/xxl-core/xxl-core.jar $(XXL_D
 	else \
 		printf "Tests Passed $(ccgreen)[$$(($(TESTS_NUMBER) - $(TESTS_FAILED)))/$(TESTS_NUMBER)]$(ccend)\n"; \
 	fi
+
+
+log:
+ifeq ($(QUIET),true)
+	@printf "Testing in silent mode...\n";
+	@(make all > $(REPORT_FILE) 2>&1);
+else
+	@(make all 2>&1 | tee $(REPORT_FILE));
+endif
+	@printf "$(ccyellow)Testing report logged in $(REPORT_FILE)$(ccend)\n";
+
+
 
 # Force target to run
 force:
@@ -65,6 +80,7 @@ clean:
 	@$(RM) tests/*/*.diff
 	@$(RM) tests/*.diff
 	@$(RM) failed_tests.txt
+	@$(RM) TESTS_REPORT.log
 
 post-clean:
 	@$(RM) saved*

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Followed by
 ```bash
 make
 ```
+If the output is too big use `make log` to log the output to a file. (You can also use `make log QUIET=true` to silence output in the terminal)
+
 You can run a single or a group of tests. But you should run make clean first. E.g:
 Running only the professor's tests
 ```bash


### PR DESCRIPTION
`make log` -> displays the output to terminal and logs it to TESTS_REPORT.log
`make log QUIET=true` -> runs silently only logging to the file